### PR TITLE
fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,8 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/quax-blocks/security/code-scanning/4](https://github.com/GalacticDynamics/quax-blocks/security/code-scanning/4)

To fix the problem, we should add a `permissions` block appropriate to the minimum required privileges for the `dist` job. Based on its steps, the job is performing checkouts and package builds, which do not require write access to the repository. The minimal recommended permission for such jobs is typically `contents: read`. 

Insert the `permissions:` block at the same level as `runs-on` within the `dist` job. Specifically, add:
```yaml
permissions:
  contents: read
```
after line 23, before the `steps` block. This restricts the job's token permissions, ensuring least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
