### PR TITLE
fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/quax-blocks/security/code-scanning/3](https://github.com/GalacticDynamics/quax-blocks/security/code-scanning/3)

To fix this problem, you should add a `permissions` block at the root of the workflow YAML (directly after `name:` and before `on:`), which restricts the GitHub Actions runner to the least required privileges — in this case, only `contents: read`. This allows actions like `actions/checkout` to operate while preventing any accidental or malicious write actions via the GITHUB_TOKEN. No actions in the workflow require broader permissions, so this change will not affect functionality. You do not need to change the jobs or add any imports. Only edit `.github/workflows/ci.yml`, by inserting the block at the very start, immediately after the workflow name header.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
